### PR TITLE
add prescale_factor for aspect ratio nodes

### DIFF
--- a/nodes/nodes.py
+++ b/nodes/nodes.py
@@ -49,15 +49,16 @@ class CR_AspectRatioSD15:
                 "aspect_ratio": (aspect_ratios,),
                 "swap_dimensions": (["Off", "On"],),
                 "upscale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
+                "prescale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
                 "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})
             }
         }
-    RETURN_TYPES = ("INT", "INT", "FLOAT", "INT", "LATENT", "STRING", )
-    RETURN_NAMES = ("width", "height", "upscale_factor", "batch_size", "empty_latent", "show_help", )
+    RETURN_TYPES = ("INT", "INT", "FLOAT", "FLOAT", "INT", "LATENT", "STRING", )
+    RETURN_NAMES = ("width", "height", "upscale_factor", "prescale_factor", "batch_size", "empty_latent", "show_help", )
     FUNCTION = "Aspect_Ratio"
     CATEGORY = icons.get("Comfyroll/Aspect Ratio")
 
-    def Aspect_Ratio(self, width, height, aspect_ratio, swap_dimensions, upscale_factor, batch_size):
+    def Aspect_Ratio(self, width, height, aspect_ratio, swap_dimensions, upscale_factor, prescale_factor, batch_size):
         if aspect_ratio == "2:3 portrait 512x768":
             width, height = 512, 768
         elif aspect_ratio == "3:2 landscape 768x512":
@@ -83,12 +84,15 @@ class CR_AspectRatioSD15:
             temp = width
             width = height
             height = temp
+
+        width = int(width*prescale_factor)
+        height = int(height*prescale_factor)
            
         latent = torch.zeros([batch_size, 4, height // 8, width // 8])
 
         show_help = "https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/wiki/Aspect-Ratio-Nodes#cr-sd15-aspect-ratio"
            
-        return(width, height, upscale_factor, batch_size, {"samples":latent}, show_help, )   
+        return(width, height, upscale_factor, prescale_factor, batch_size, {"samples":latent}, show_help, )   
 
 #---------------------------------------------------------------------------------------------------------------------#
 class CR_SDXLAspectRatio:
@@ -116,15 +120,16 @@ class CR_SDXLAspectRatio:
                 "aspect_ratio": (aspect_ratios,),
                 "swap_dimensions": (["Off", "On"],),
                 "upscale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
+                "prescale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
                 "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})
             }
         }
-    RETURN_TYPES = ("INT", "INT", "FLOAT", "INT", "LATENT", "STRING", )
-    RETURN_NAMES = ("width", "height", "upscale_factor", "batch_size", "empty_latent", "show_help", )
+    RETURN_TYPES = ("INT", "INT", "FLOAT", "FLOAT", "INT", "LATENT", "STRING", )
+    RETURN_NAMES = ("width", "height", "upscale_factor", "prescale_factor", "batch_size", "empty_latent", "show_help", )
     FUNCTION = "Aspect_Ratio"
     CATEGORY = icons.get("Comfyroll/Aspect Ratio")
 
-    def Aspect_Ratio(self, width, height, aspect_ratio, swap_dimensions, upscale_factor, batch_size):
+    def Aspect_Ratio(self, width, height, aspect_ratio, swap_dimensions, upscale_factor, prescale_factor, batch_size):
         if aspect_ratio == "1:1 square 1024x1024":
             width, height = 1024, 1024
         elif aspect_ratio == "3:4 portrait 896x1152":
@@ -148,12 +153,15 @@ class CR_SDXLAspectRatio:
             temp = width
             width = height
             height = temp
+
+        width = int(width*prescale_factor)
+        height = int(height*prescale_factor)
            
         latent = torch.zeros([batch_size, 4, height // 8, width // 8])
 
         show_help = "https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/wiki/Aspect-Ratio-Nodes#cr-sdxl-aspect-ratio"
            
-        return(width, height, upscale_factor, batch_size, {"samples":latent}, show_help, )  
+        return(width, height, upscale_factor, prescale_factor, batch_size, {"samples":latent}, show_help, )  
 
 #---------------------------------------------------------------------------------------------------------------------#
 class CR_AspectRatio:
@@ -189,15 +197,16 @@ class CR_AspectRatio:
                 "aspect_ratio": (aspect_ratios,),
                 "swap_dimensions": (["Off", "On"],),
                 "upscale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
+                "prescale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
                 "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})
             }
         }
-    RETURN_TYPES = ("INT", "INT", "FLOAT", "INT", "LATENT", "STRING", )
-    RETURN_NAMES = ("width", "height", "upscale_factor", "batch_size", "empty_latent", "show_help", )
+    RETURN_TYPES = ("INT", "INT", "FLOAT", "FLOAT", "INT", "LATENT", "STRING", )
+    RETURN_NAMES = ("width", "height", "upscale_factor", "prescale_factor", "batch_size", "empty_latent", "show_help", )
     FUNCTION = "Aspect_Ratio"
     CATEGORY = icons.get("Comfyroll/Aspect Ratio")
 
-    def Aspect_Ratio(self, width, height, aspect_ratio, swap_dimensions, upscale_factor, batch_size):
+    def Aspect_Ratio(self, width, height, aspect_ratio, swap_dimensions, upscale_factor, prescale_factor, batch_size):
         
         # SD1.5
         if aspect_ratio == "SD1.5 - 1:1 square 512x512":
@@ -242,12 +251,15 @@ class CR_AspectRatio:
             temp = width
             width = height
             height = temp
+
+        width = int(width*prescale_factor)
+        height = int(height*prescale_factor)
            
         latent = torch.zeros([batch_size, 4, height // 8, width // 8])
 
         show_help = "https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/wiki/Aspect-Ratio-Nodes#cr-aspect-ratio"
            
-        return(width, height, upscale_factor, batch_size, {"samples":latent}, show_help, )    
+        return(width, height, upscale_factor, prescale_factor, batch_size, {"samples":latent}, show_help, )    
 #---------------------------------------------------------------------------------------------------------------------#
 # Other Nodes
 #---------------------------------------------------------------------------------------------------------------------#

--- a/nodes/nodes.py
+++ b/nodes/nodes.py
@@ -48,17 +48,16 @@ class CR_AspectRatioSD15:
                 "height": ("INT", {"default": 512, "min": 64, "max": 8192}),
                 "aspect_ratio": (aspect_ratios,),
                 "swap_dimensions": (["Off", "On"],),
-                "upscale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
-                "prescale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
+                "upscale_factor": ("FLOAT", {"default": 1, "min": 0.1, "max": 100, "step": 0.1}),
                 "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})
             }
         }
-    RETURN_TYPES = ("INT", "INT", "FLOAT", "FLOAT", "INT", "LATENT", "STRING", )
-    RETURN_NAMES = ("width", "height", "upscale_factor", "prescale_factor", "batch_size", "empty_latent", "show_help", )
+    RETURN_TYPES = ("INT", "INT", "FLOAT", "INT", "LATENT", "STRING", )
+    RETURN_NAMES = ("width", "height", "upscale_factor", "batch_size", "empty_latent", "show_help", )
     FUNCTION = "Aspect_Ratio"
     CATEGORY = icons.get("Comfyroll/Aspect Ratio")
 
-    def Aspect_Ratio(self, width, height, aspect_ratio, swap_dimensions, upscale_factor, prescale_factor, batch_size):
+    def Aspect_Ratio(self, width, height, aspect_ratio, swap_dimensions, upscale_factor, batch_size):
         if aspect_ratio == "2:3 portrait 512x768":
             width, height = 512, 768
         elif aspect_ratio == "3:2 landscape 768x512":
@@ -85,14 +84,11 @@ class CR_AspectRatioSD15:
             width = height
             height = temp
 
-        width = int(width*prescale_factor)
-        height = int(height*prescale_factor)
-           
         latent = torch.zeros([batch_size, 4, height // 8, width // 8])
 
         show_help = "https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/wiki/Aspect-Ratio-Nodes#cr-sd15-aspect-ratio"
            
-        return(width, height, upscale_factor, prescale_factor, batch_size, {"samples":latent}, show_help, )   
+        return(width, height, upscale_factor, batch_size, {"samples":latent}, show_help, )   
 
 #---------------------------------------------------------------------------------------------------------------------#
 class CR_SDXLAspectRatio:
@@ -119,17 +115,16 @@ class CR_SDXLAspectRatio:
                 "height": ("INT", {"default": 1024, "min": 64, "max": 8192}),
                 "aspect_ratio": (aspect_ratios,),
                 "swap_dimensions": (["Off", "On"],),
-                "upscale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
-                "prescale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
+                "upscale_factor": ("FLOAT", {"default": 1, "min": 0.1, "max": 100, "step": 0.1}),
                 "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})
             }
         }
-    RETURN_TYPES = ("INT", "INT", "FLOAT", "FLOAT", "INT", "LATENT", "STRING", )
-    RETURN_NAMES = ("width", "height", "upscale_factor", "prescale_factor", "batch_size", "empty_latent", "show_help", )
+    RETURN_TYPES = ("INT", "INT", "FLOAT", "INT", "LATENT", "STRING", )
+    RETURN_NAMES = ("width", "height", "upscale_factor", "batch_size", "empty_latent", "show_help", )
     FUNCTION = "Aspect_Ratio"
     CATEGORY = icons.get("Comfyroll/Aspect Ratio")
 
-    def Aspect_Ratio(self, width, height, aspect_ratio, swap_dimensions, upscale_factor, prescale_factor, batch_size):
+    def Aspect_Ratio(self, width, height, aspect_ratio, swap_dimensions, upscale_factor, batch_size):
         if aspect_ratio == "1:1 square 1024x1024":
             width, height = 1024, 1024
         elif aspect_ratio == "3:4 portrait 896x1152":
@@ -154,14 +149,11 @@ class CR_SDXLAspectRatio:
             width = height
             height = temp
 
-        width = int(width*prescale_factor)
-        height = int(height*prescale_factor)
-           
         latent = torch.zeros([batch_size, 4, height // 8, width // 8])
 
         show_help = "https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/wiki/Aspect-Ratio-Nodes#cr-sdxl-aspect-ratio"
            
-        return(width, height, upscale_factor, prescale_factor, batch_size, {"samples":latent}, show_help, )  
+        return(width, height, upscale_factor, batch_size, {"samples":latent}, show_help, )  
 
 #---------------------------------------------------------------------------------------------------------------------#
 class CR_AspectRatio:
@@ -196,8 +188,8 @@ class CR_AspectRatio:
                 "height": ("INT", {"default": 1024, "min": 64, "max": 8192}),
                 "aspect_ratio": (aspect_ratios,),
                 "swap_dimensions": (["Off", "On"],),
-                "upscale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
-                "prescale_factor": ("FLOAT", {"default": 1, "min": 1, "max": 100}),
+                "upscale_factor": ("FLOAT", {"default": 1, "min": 0.1, "max": 100, "step": 0.1}),
+                "prescale_factor": ("FLOAT", {"default": 1, "min": 0.1, "max": 100, "step": 0.1}),
                 "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})
             }
         }


### PR DESCRIPTION
sidenote: you don't need to create a temp variable to swap width and height, in python you can just do

```python
width, height = height, width
```

I didn't make any changes to that since I didn't knew if there was some reason to use a temp var

Edit: closes #56