### PR TITLE
#72 Make the font path OS agnostic

### DIFF
--- a/nodes/pil_text.py
+++ b/nodes/pil_text.py
@@ -406,7 +406,7 @@ class CR_SimpleTextWatermark:
             draw = ImageDraw.Draw(textlayer)
             
             # Load the font
-            font_file = "fonts\\" + str(font_name)   
+            font_file = os.path.join("fonts", str(font_name))   
             resolved_font_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), font_file)
             font = ImageFont.truetype(str(resolved_font_path), size=font_size)
             


### PR DESCRIPTION
This works on Linux, assume it works on Windows as well.