### PR TITLE
Fix "NameError: name 'os' is not defined"

### DIFF
--- a/nodes/nodes_utils_text.py
+++ b/nodes/nodes_utils_text.py
@@ -3,6 +3,7 @@
 # for ComfyUI                                                 https://github.com/comfyanonymous/ComfyUI                                               
 #---------------------------------------------------------------------------------------------------------------------#
 
+import os
 import csv
 import io
 from ..categories import icons


### PR DESCRIPTION
Fixes this error I get:

```
2024 - 01 - 18 23:16:45, 183 - root - ERROR - Traceback (most recent call last):
File "/ComfyUI/execution.py", line 155, in recursive_execute
output_data, output_ui = get_output_data(obj, input_data_all)
File "/ComfyUI/execution.py", line 85, in get_output_data
return_values = map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True)
File "/ComfyUI/execution.py", line 78, in map_node_over_list
results.append(getattr(obj, func)(**slice_dict(input_data_all, i)))
File "/ComfyUI/custom_nodes/ComfyUI_Comfyroll_CustomNodes/nodes/nodes_utils_text.py", line 172, in save_list
while os.path.exists(filepath):
NameError: name 'os' is not defined
```