### PR TITLE
Added check for /usr/share/fonts/truetype directory and provided an a…

### DIFF
--- a/nodes/nodes_graphics_text.py
+++ b/nodes/nodes_graphics_text.py
@@ -461,6 +461,8 @@ class CR_SelectFont:
        # Default debian-based Linux & MacOS font dirs
         elif platform.system() == "Linux":
             font_dir = "/usr/share/fonts/truetype"
+            if not os.path.exists(font_dir):
+                font_dir = "/usr/share/fonts/TTF"
         elif platform.system() == "Darwin":
             font_dir = "/System/Library/Fonts"    
  


### PR DESCRIPTION
When running under Arch Linux received an error:
```
Received an error:
[ERROR] An error occurred while retrieving information for the 'CR Select Font' node.
Traceback (most recent call last):
  File "[redacted]/ComfyUI/server.py", line 420, in get_object_info
    out[x] = node_info(x)
             ^^^^^^^^^^^^
  File "[redacted]/ComfyUI/server.py", line 398, in node_info
    info['input'] = obj_class.INPUT_TYPES()
                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "[redacted]/ComfyUI/custom_nodes/ComfyUI_Comfyroll_CustomNodes/nodes/nodes_graphics_text.py", line 467, in INPUT_TYPES
    file_list = [f for f in os.listdir(font_dir) if os.path.isfile(os.path.join(font_dir, f)) and f.lower().endswith(".ttf")]
                            ^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/fonts/truetype'
```
The directory (/usr/share/fonts/truetype) doesn't not exist on my system and probably for other Arch Linux users as shown in example structure (https://wiki.archlinux.org/title/fonts#Manual_installation).  After change fonts appear in Select Font node.  