### PR TITLE
fix crash discovering fonts on Linux

### DIFF
--- a/nodes/nodes_graphics_text.py
+++ b/nodes/nodes_graphics_text.py
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------------------------------------------------#
-# Comfyroll Studio custom nodes by RockOfFire and Akatsuzi    https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes                             
-# for ComfyUI                                                 https://github.com/comfyanonymous/ComfyUI                                               
+# Comfyroll Studio custom nodes by RockOfFire and Akatsuzi    https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes
+# for ComfyUI                                                 https://github.com/comfyanonymous/ComfyUI
 #---------------------------------------------------------------------------------------------------------------------#
 
 import numpy as np
@@ -19,8 +19,8 @@ except ImportError:
     import subprocess
     subprocess.check_call(['python', '-m', 'pip', 'install', 'python_bidi'])
 
-try:    
-    import arabic_reshaper    
+try:
+    import arabic_reshaper
 except ImportError:
     import subprocess
     subprocess.check_call(['python', '-m', 'pip', 'install', 'arabic_reshaper'])
@@ -42,28 +42,53 @@ class AnyType(str):
 
 any_type = AnyType("*")
 
+def get_builtin_fonts():
+    try:
+        font_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "fonts")
+        return [f for f in os.listdir(font_dir) if os.path.isfile(os.path.join(font_dir, f)) and f.lower().endswith(".ttf")]
+    except OSError:
+        return []
+
+def get_system_fonts():
+    if platform.system() == "Windows":
+        system_root = os.environ.get("SystemRoot")
+        font_dirs = (os.path.join(system_root, "Fonts") if system_root else None,)
+    # Default Linux & MacOS font dirs
+    elif platform.system() == "Linux":
+        font_dirs = ("/usr/share/fonts/truetype", "/usr/share/fonts/TTF")
+    elif platform.system() == "Darwin":
+        font_dirs = ("/System/Library/Fonts",)
+    file_list = []
+    for font_dir in font_dirs:
+        if not os.path.exists(font_dir):
+            continue
+        try:
+            file_list += [f for f in os.listdir(font_dir) if os.path.isfile(os.path.join(font_dir, f)) and f.lower().endswith(".ttf")]
+        except OSError:
+            continue
+    return file_list
+
 #---------------------------------------------------------------------------------------------------------------------#
-          
-ALIGN_OPTIONS = ["center", "top", "bottom"]                 
+
+ALIGN_OPTIONS = ["center", "top", "bottom"]
 ROTATE_OPTIONS = ["text center", "image center"]
 JUSTIFY_OPTIONS = ["center", "left", "right"]
 PERSPECTIVE_OPTIONS = ["top", "bottom", "left", "right"]
-  
+
 #---------------------------------------------------------------------------------------------------------------------#
 class CR_OverlayText:
 
     @classmethod
     def INPUT_TYPES(s):
 
-        font_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "fonts")       
-        file_list = [f for f in os.listdir(font_dir) if os.path.isfile(os.path.join(font_dir, f)) and f.lower().endswith(".ttf")]
-                        
+        file_list = get_builtin_fonts()
+
         return {"required": {
                 "image": ("IMAGE",),
                 "text": ("STRING", {"multiline": True, "default": "text"}),
                 "font_name": (file_list,),
                 "font_size": ("INT", {"default": 50, "min": 1, "max": 1024}),
-                "font_color": (COLORS,), 
+                "font_color": (COLORS,),
                 "align": (ALIGN_OPTIONS,),
                 "justify": (JUSTIFY_OPTIONS,),
                 "margins": ("INT", {"default": 0, "min": -1024, "max": 1024}),
@@ -74,7 +99,7 @@ class CR_OverlayText:
                 "rotation_options": (ROTATE_OPTIONS,),
                 },
                 "optional": {"font_color_hex": ("STRING", {"multiline": False, "default": "#000000"})
-                }        
+                }
     }
 
     RETURN_TYPES = ("IMAGE", "STRING",)
@@ -82,16 +107,16 @@ class CR_OverlayText:
     FUNCTION = "overlay_text"
     CATEGORY = icons.get("Comfyroll/Graphics/Text")
 
-    def overlay_text(self, image, text, font_name, font_size, font_color,  
+    def overlay_text(self, image, text, font_name, font_size, font_color,
                      margins, line_spacing,
                      position_x, position_y,
                      align, justify,
                      rotation_angle, rotation_options,
                      font_color_hex='#000000'):
 
-        # Get RGB values for the text color  
+        # Get RGB values for the text color
         text_color = get_color_values(font_color, font_color_hex, color_mapping)
-      
+
         # Convert tensor images
         image_3d = image[0, :, :, :]
 
@@ -99,19 +124,19 @@ class CR_OverlayText:
         back_image = tensor2pil(image_3d)
         text_image = Image.new('RGB', back_image.size, text_color)
         text_mask = Image.new('L', back_image.size)
-        
+
         # Draw the text on the text mask
         rotated_text_mask = draw_masked_text(text_mask, text, font_name, font_size,
-                                             margins, line_spacing, 
+                                             margins, line_spacing,
                                              position_x, position_y,
                                              align, justify,
                                              rotation_angle, rotation_options)
 
-        # Composite the text image onto the background image using the rotated text mask       
-        image_out = Image.composite(text_image, back_image, rotated_text_mask)       
+        # Composite the text image onto the background image using the rotated text mask
+        image_out = Image.composite(text_image, back_image, rotated_text_mask)
 
         show_help = "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/Text-Nodes#cr-overlay-text"
-        
+
         # Convert the PIL image back to a torch tensor
         return (pil2tensor(image_out), show_help,)
 
@@ -121,12 +146,11 @@ class CR_DrawText:
     @classmethod
     def INPUT_TYPES(s):
 
-        font_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "fonts")       
-        file_list = [f for f in os.listdir(font_dir) if os.path.isfile(os.path.join(font_dir, f)) and f.lower().endswith(".ttf")]
-                      
+        file_list = get_builtin_fonts()
+
         return {"required": {
                     "image_width": ("INT", {"default": 512, "min": 64, "max": 2048}),
-                    "image_height": ("INT", {"default": 512, "min": 64, "max": 2048}),  
+                    "image_height": ("INT", {"default": 512, "min": 64, "max": 2048}),
                     "text": ("STRING", {"multiline": True, "default": "text"}),
                     "font_name": (file_list,),
                     "font_size": ("INT", {"default": 50, "min": 1, "max": 1024}),
@@ -139,12 +163,12 @@ class CR_DrawText:
                     "position_x": ("INT", {"default": 0, "min": -4096, "max": 4096}),
                     "position_y": ("INT", {"default": 0, "min": -4096, "max": 4096}),
                     "rotation_angle": ("FLOAT", {"default": 0.0, "min": -360.0, "max": 360.0, "step": 0.1}),
-                    "rotation_options": (ROTATE_OPTIONS,),            
+                    "rotation_options": (ROTATE_OPTIONS,),
                 },
                 "optional": {
                     "font_color_hex": ("STRING", {"multiline": False, "default": "#000000"}),
                     "bg_color_hex": ("STRING", {"multiline": False, "default": "#000000"})
-                }          
+                }
     }
 
     RETURN_TYPES = ("IMAGE", "STRING",)
@@ -153,7 +177,7 @@ class CR_DrawText:
     CATEGORY = icons.get("Comfyroll/Graphics/Text")
 
     def draw_text(self, image_width, image_height, text,
-                  font_name, font_size, font_color, 
+                  font_name, font_size, font_color,
                   background_color,
                   margins, line_spacing,
                   position_x, position_y,
@@ -163,8 +187,8 @@ class CR_DrawText:
 
         # Get RGB values for the text and background colors
         text_color = get_color_values(font_color, font_color_hex, color_mapping)
-        bg_color = get_color_values(background_color, bg_color_hex, color_mapping) 
-        
+        bg_color = get_color_values(background_color, bg_color_hex, color_mapping)
+
         # Create PIL images for the text and background layers and text mask
         size = (image_width, image_height)
         text_image = Image.new('RGB', size, text_color)
@@ -180,21 +204,20 @@ class CR_DrawText:
 
         # Composite the text image onto the background image using the rotated text mask
         image_out = Image.composite(text_image, back_image, rotated_text_mask)
-        
+
         show_help = "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/Text-Nodes#cr-draw-text"
 
         # Convert the PIL image back to a torch tensor
         return (pil2tensor(image_out), show_help,)
-    
+
 #---------------------------------------------------------------------------------------------------------------------#
 class CR_MaskText:
 
     @classmethod
     def INPUT_TYPES(s):
 
-        font_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "fonts")       
-        file_list = [f for f in os.listdir(font_dir) if os.path.isfile(os.path.join(font_dir, f)) and f.lower().endswith(".ttf")]
-                      
+        file_list = get_builtin_fonts()
+
         return {"required": {
                     "image": ("IMAGE",),
                     "text": ("STRING", {"multiline": True, "default": "text"}),
@@ -208,35 +231,35 @@ class CR_MaskText:
                     "position_x": ("INT", {"default": 0, "min": -4096, "max": 4096}),
                     "position_y": ("INT", {"default": 0, "min": -4096, "max": 4096}),
                     "rotation_angle": ("FLOAT", {"default": 0.0, "min": -360.0, "max": 360.0, "step": 0.1}),
-                    "rotation_options": (ROTATE_OPTIONS,),             
+                    "rotation_options": (ROTATE_OPTIONS,),
                 },
                 "optional": {
                     "bg_color_hex": ("STRING", {"multiline": False, "default": "#000000"})
-                }         
+                }
     }
 
     RETURN_TYPES = ("IMAGE", "STRING",)
     RETURN_NAMES = ("IMAGE", "show_help",)
     FUNCTION = "mask_text"
     CATEGORY = icons.get("Comfyroll/Graphics/Text")
-    
+
     def mask_text(self, image, text, font_name, font_size,
-                  margins, line_spacing, 
-                  position_x, position_y, background_color, 
+                  margins, line_spacing,
+                  position_x, position_y, background_color,
                   align, justify,
                   rotation_angle, rotation_options,
                   bg_color_hex='#000000'):
 
         # Get RGB values for the background color
-        bg_color = get_color_values(background_color, bg_color_hex, color_mapping)   
-   
+        bg_color = get_color_values(background_color, bg_color_hex, color_mapping)
+
         # Convert tensor images
         image_3d = image[0, :, :, :]
-            
+
         # Create PIL images for the text and background layers and text mask
-        text_image = tensor2pil(image_3d)        
+        text_image = tensor2pil(image_3d)
         text_mask = Image.new('L', text_image.size)
-        background_image = Image.new('RGB', text_mask.size, bg_color)        
+        background_image = Image.new('RGB', text_mask.size, bg_color)
 
         # Draw the text on the text mask
         rotated_text_mask = draw_masked_text(text_mask, text, font_name, font_size,
@@ -246,13 +269,13 @@ class CR_MaskText:
                                              rotation_angle, rotation_options)
 
         # Invert the text mask (so the text is white and the background is black)
-        text_mask = ImageOps.invert(rotated_text_mask)        
+        text_mask = ImageOps.invert(rotated_text_mask)
 
-        # Composite the text image onto the background image using the inverted text mask        
+        # Composite the text image onto the background image using the inverted text mask
         image_out = Image.composite(background_image, text_image, text_mask)
 
         show_help = "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/Text-Nodes#cr-mask-text"
-        
+
         # Convert the PIL image back to a torch tensor
         return (pil2tensor(image_out), show_help,)
 
@@ -262,9 +285,8 @@ class CR_CompositeText:
     @classmethod
     def INPUT_TYPES(s):
 
-        font_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "fonts")       
-        file_list = [f for f in os.listdir(font_dir) if os.path.isfile(os.path.join(font_dir, f)) and f.lower().endswith(".ttf")]
-                             
+        file_list = get_builtin_fonts()
+
         return {"required": {
                     "image_text": ("IMAGE",),
                     "image_background": ("IMAGE",),
@@ -279,16 +301,16 @@ class CR_CompositeText:
                     "position_y": ("INT", {"default": 0, "min": -4096, "max": 4096}),
                     "rotation_angle": ("FLOAT", {"default": 0.0, "min": -360.0, "max": 360.0, "step": 0.1}),
                     "rotation_options": (ROTATE_OPTIONS,),
-                }        
+                }
     }
 
     RETURN_TYPES = ("IMAGE", "STRING",)
     RETURN_NAMES = ("IMAGE", "show_help",)
     FUNCTION = "composite_text"
     CATEGORY = icons.get("Comfyroll/Graphics/Text")
-    
+
     def composite_text(self, image_text, image_background, text,
-                       font_name, font_size, 
+                       font_name, font_size,
                        margins, line_spacing,
                        position_x, position_y,
                        align, justify,
@@ -297,7 +319,7 @@ class CR_CompositeText:
         # Convert tensor images
         image_text_3d = image_text[0, :, :, :]
         image_back_3d = image_background[0, :, :, :]
-            
+
         # Create PIL images for the text and background layers and text mask
         text_image = tensor2pil(image_text_3d)
         back_image = tensor2pil(image_back_3d)
@@ -309,24 +331,24 @@ class CR_CompositeText:
                                              position_x, position_y,
                                              align, justify,
                                              rotation_angle, rotation_options)
-                                             
+
         # Composite the text image onto the background image using the rotated text mask
         image_out = Image.composite(text_image, back_image, rotated_text_mask)
 
         show_help = "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/Text-Nodes#cr-composite-text"
-        
+
         # Convert the PIL image back to a torch tensor
         return (pil2tensor(image_out), show_help,)
 
 #---------------------------------------------------------------------------------------------------------------------#
 class CR_ArabicTextRTL:
-    
+
     @classmethod
     def INPUT_TYPES(s):
-                        
+
         return {"required": {
                 "arabic_text": ("STRING", {"multiline": True, "default": "شمس"}),
-                }          
+                }
         }
 
     RETURN_TYPES = ("STRING", "STRING", )
@@ -337,46 +359,45 @@ class CR_ArabicTextRTL:
     def adjust_arabic_to_rtl(self, arabic_text):
         """
         Adjust Arabic text to read from right to left (RTL).
-        
+
         Args:
             arabic_text (str): The Arabic text to be adjusted.
-            
+
         Returns:
             str: The adjusted Arabic text in RTL format.
         """
-        
+
         arabic_text_reshaped = arabic_reshaper.reshape(arabic_text)
         rtl_text = get_display(arabic_text_reshaped)
-        
+
         show_help = "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/Text-Nodes#cr-arabic-text-rtl"
-                
+
         return (rtl_text, show_help,)
 
 #---------------------------------------------------------------------------------------------------------------------#
 class CR_SimpleTextWatermark:
-    
+
     @classmethod
     def INPUT_TYPES(s):
 
-        font_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "fonts")       
-        file_list = [f for f in os.listdir(font_dir) if os.path.isfile(os.path.join(font_dir, f)) and f.lower().endswith(".ttf")]
-               
-        ALIGN_OPTIONS = ["center", "top left", "top center", "top right", "bottom left", "bottom center", "bottom right"]  
-                   
+        file_list = get_builtin_fonts()
+
+        ALIGN_OPTIONS = ["center", "top left", "top center", "top right", "bottom left", "bottom center", "bottom right"]
+
         return {"required": {
                     "image": ("IMAGE",),
                     "text": ("STRING", {"multiline": False, "default": "@ your name"}),
                     "align": (ALIGN_OPTIONS,),
                     "opacity": ("FLOAT", {"default": 0.30, "min": 0.00, "max": 1.00, "step": 0.01}),
                     "font_name": (file_list,),
-                    "font_size": ("INT", {"default": 50, "min": 1, "max": 1024}),                
-                    "font_color": (COLORS,), 
+                    "font_size": ("INT", {"default": 50, "min": 1, "max": 1024}),
+                    "font_color": (COLORS,),
                     "x_margin": ("INT", {"default": 20, "min": -1024, "max": 1024}),
                     "y_margin": ("INT", {"default": 20, "min": -1024, "max": 1024}),
                 },
                 "optional": {
                     "font_color_hex": ("STRING", {"multiline": False, "default": "#000000"}),
-                }     
+                }
         }
 
     RETURN_TYPES = ("IMAGE", "STRING", )
@@ -388,87 +409,78 @@ class CR_SimpleTextWatermark:
                      font_name, font_size, font_color,
                      opacity, x_margin, y_margin, font_color_hex='#000000'):
 
-        # Get RGB values for the text color  
+        # Get RGB values for the text color
         text_color = get_color_values(font_color, font_color_hex, color_mapping)
-        
+
         total_images = []
-        
+
         for img in image:
-            
+
             # Create PIL images for the background layer
             img = tensor2pil(img)
-            
+
             textlayer = Image.new("RGBA", img.size)
             draw = ImageDraw.Draw(textlayer)
-            
+
             # Load the font
-            font_file = os.path.join("fonts", str(font_name))             
+            font_file = os.path.join("fonts", str(font_name))
             resolved_font_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), font_file)
             font = ImageFont.truetype(str(resolved_font_path), size=font_size)
-            
+
             # Get the size of the text
             textsize = get_text_size(draw, text, font)
-            
+
             # Calculate the position to place the text based on the alignment
             if align == 'center':
                 textpos = [(img.size[0] - textsize[0]) // 2, (img.size[1] - textsize[1]) // 2]
             elif align == 'top left':
                 textpos = [x_margin, y_margin]
             elif align == 'top center':
-                textpos = [(img.size[0] - textsize[0]) // 2, y_margin]    
+                textpos = [(img.size[0] - textsize[0]) // 2, y_margin]
             elif align == 'top right':
                 textpos = [img.size[0] - textsize[0] - x_margin, y_margin]
             elif align == 'bottom left':
                 textpos = [x_margin, img.size[1] - textsize[1] - y_margin]
             elif align == 'bottom center':
-                textpos = [(img.size[0] - textsize[0]) // 2, img.size[1] - textsize[1] - y_margin]             
+                textpos = [(img.size[0] - textsize[0]) // 2, img.size[1] - textsize[1] - y_margin]
             elif align == 'bottom right':
                 textpos = [img.size[0] - textsize[0] - x_margin, img.size[1] - textsize[1] - y_margin]
-            
+
             # Draw the text on the text layer
             draw.text(textpos, text, font=font, fill=text_color)
-            
+
             # Adjust the opacity of the text layer if needed
             if opacity != 1:
                 textlayer = reduce_opacity(textlayer, opacity)
-            
+
             # Composite the text layer on top of the original image
             out_image = Image.composite(textlayer, img, textlayer)
- 
+
             # convert to tensor
             out_image = np.array(out_image.convert("RGB")).astype(np.float32) / 255.0
             out_image = torch.from_numpy(out_image).unsqueeze(0)
             total_images.append(out_image)
 
         images_out = torch.cat(total_images, 0)
-        
+
         show_help = "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/Text-Nodes#cr-simple-text-watermark"
- 
+
         # Convert the PIL image back to a torch tensor
         return (images_out, show_help, )
 
-#---------------------------------------------------------------------------------------------------------------------#        
+#---------------------------------------------------------------------------------------------------------------------#
 class CR_SelectFont:
     def __init__(self):
         pass
-        
+
     @classmethod
     def INPUT_TYPES(cls):
-    
-        if platform.system() == "Windows":
-            system_root = os.environ.get("SystemRoot")
-            font_dir = os.path.join(system_root, "Fonts") if system_root else None
-       # Default debian-based Linux & MacOS font dirs
-        elif platform.system() == "Linux":
-            font_dir = "/usr/share/fonts/truetype"
-        elif platform.system() == "Darwin":
-            font_dir = "/System/Library/Fonts"    
- 
-        file_list = [f for f in os.listdir(font_dir) if os.path.isfile(os.path.join(font_dir, f)) and f.lower().endswith(".ttf")]
-                        
+
+        file_list = get_system_fonts()
+
         return {"required": {
                 "font_name": (file_list,),
-                }       
+                }
     }
 
     RETURN_TYPES = (any_type, "STRING",)
@@ -477,11 +489,11 @@ class CR_SelectFont:
     CATEGORY = icons.get("Comfyroll/Graphics/Text")
 
     def select_font(self, font_name):
-    
-        show_help = "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/Text-Nodes#cr-select-font"    
-       
-        return (font_name, show_help,)     
-  
+
+        show_help = "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/Text-Nodes#cr-select-font"
+
+        return (font_name, show_help,)
+
 #---------------------------------------------------------------------------------------------------------------------#
 # MAPPINGS
 #---------------------------------------------------------------------------------------------------------------------#
@@ -489,7 +501,7 @@ class CR_SelectFont:
 '''
 NODE_CLASS_MAPPINGS = {
     "CR Overlay Text": CR_OverlayText,
-    "CR Draw Text": CR_DrawText, 
+    "CR Draw Text": CR_DrawText,
     "CR Mask Text": CR_MaskText,
     "CR Composite Text": CR_CompositeText,
     "CR Draw Perspective Text": CR_DrawPerspectiveText,


### PR DESCRIPTION
currently the extension crashes on every startup and every time the browser refreshes the session on Linux due to the font directories it looks for not existing and it doesn't handle exceptions.

this pull reduces code duplication by moving font discovery into functions and it also adds error handling when discovering fonts. i set it up to search common font directories on Linux.

the diff is fairly large because my editor cleaned up a bunch of trailing whitespace. if you _really_ want to keep it for whatever reason i can amend this pull to only affect the font discovery part.

i'm not sure why some nodes only used the builtin fonts and one of them used system fonts instead, i assume it's for a reason so i provided separate functions. if you wanted to just use all available fonts a simple function like:

```python
def get_all_fonts():
  return get_builtin_fonts() + get_system_fonts()
```

would work.