### PR TITLE
Add CR_ListProduct node

### DIFF
--- a/node_mappings.py
+++ b/node_mappings.py
@@ -76,6 +76,7 @@ NODE_CLASS_MAPPINGS = {
     "CR Repeater": CR_Repeater,     
     "CR XY Product": CR_XYProduct,  
     "CR Text List To String": CR_TextListToString,   
+    "CR List Product": CR_ListProduct,
     ### Aspect Ratio Nodes
     "CR SD1.5 Aspect Ratio": CR_AspectRatioSD15,
     "CR SDXL Aspect Ratio": CR_SDXLAspectRatio,
@@ -323,6 +324,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "CR Repeater": "🛠️ CR Repeater",    
     "CR XY Product": "🛠️ CR XY Product",      
     "CR Text List To String": "🛠️ CR Text List To String",   
+    "CR List Product": "🛠️ CR List Product",
     ### Aspect Ratio Nodes
     "CR SD1.5 Aspect Ratio": "🔳 CR SD1.5 Aspect Ratio",
     "CR SDXL Aspect Ratio": "🔳 CR SDXL Aspect Ratio",    

--- a/nodes/nodes_graphics_text.py
+++ b/nodes/nodes_graphics_text.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 import torch
+import glob
 import os
 import platform
 from PIL import Image, ImageDraw, ImageOps, ImageFont
@@ -460,12 +461,12 @@ class CR_SelectFont:
             font_dir = os.path.join(system_root, "Fonts") if system_root else None
        # Default debian-based Linux & MacOS font dirs
         elif platform.system() == "Linux":
-            font_dir = "/usr/share/fonts/truetype"
+            font_dir = "/usr/share/fonts"
         elif platform.system() == "Darwin":
             font_dir = "/System/Library/Fonts"    
  
-        file_list = [f for f in os.listdir(font_dir) if os.path.isfile(os.path.join(font_dir, f)) and f.lower().endswith(".ttf")]
-                        
+        file_list = glob.glob(os.path.join(font_dir, "**", "*.ttf"))
+
         return {"required": {
                 "font_name": (file_list,),
                 }       

--- a/nodes/nodes_list.py
+++ b/nodes/nodes_list.py
@@ -832,6 +832,27 @@ class CR_ValueCycler:
 
         return (float_list_out, int_list_out, show_help, )    
 
+class CR_ListProduct:
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {
+            "x": (any_type, ),
+            "y": (any_type, ),
+            }
+        }
+
+    INPUT_IS_LIST = (True, True,)
+    RETURN_TYPES = (any_type, any_type, "INT")
+    RETURN_NAMES = ("out x", "out y", "Span")
+    OUTPUT_IS_LIST = (True, True, False)
+    FUNCTION = "cycle"
+    CATEGORY = icons.get("Comfyroll/List")
+
+    def cycle(self, x, y):
+        y_values, x_values = zip(*product(y, x))
+        return list(x_values), list(y_values), len(x)
+
 #---------------------------------------------------------------------------------------------------------------------#
 # MAPPINGS
 #---------------------------------------------------------------------------------------------------------------------#
@@ -856,6 +877,7 @@ NODE_CLASS_MAPPINGS = {
     "CR Batch Images From List": CR_MakeBatchFromImageList,
     "CR Intertwine Lists" : CR_IntertwineLists,
     "CR Repeater": CR_Repeater,    
+    "CR List Product": CR_ListProduct,
     "CR XY Product": CR_XYProduct,
     "CR Text List To String": CR_TextListToString,
 }

--- a/nodes/nodes_list.py
+++ b/nodes/nodes_list.py
@@ -67,6 +67,7 @@ class CR_TextList:
         return {"required": {"multiline_text": ("STRING", {"multiline": True, "default": "text"}),
                              "start_index": ("INT", {"default": 0, "min": 0, "max": 9999}),
                              "max_rows": ("INT", {"default": 1000, "min": 1, "max": 9999}),
+                             "loops": ("INT", {"default": 1, "min": 1, "max": 999}),
                             }
         }
 


### PR DESCRIPTION
This PR creates a node that will take two lists, and run the python function `product()` on them then unzip the resulting list of tuples into two lists. The purpose is to get two lists which when consumed together go through all the combinations of the two original lists. This is very useful for generating XY-Plots in a single queued job on absolutely anything when used along side the `CR_TextList`, `CR_IntegerRangeList`, `CR_FloatRangeList` & `CR_ImageGrid` node. The `span` output gives the X dimension of the plot so that that can drive the `max_columns` input of the image grid.

[An example crossing the checkpoint and CFG](https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/files/14232181/CR_XY.json)

Also fixed a couple of issues.

1. `CR_Textlist` had been recently updated to take a `loops` parameter, but it had no widget. Broke the node, so added the widget.
1. `CR_SelectFont` failed with a `FileNotFound` exception on my system as no `truetype` directory existed under `/usr/share/fonts`. Used the standard library `glob()` function to search for `.ttf` files from the `/usr/share/fonts` level instead.
