### PR TITLE
Close opened plots to save memory and stop matplotlib from complaining

### DIFF
--- a/nodes/nodes_graphics_matplot.py
+++ b/nodes/nodes_graphics_matplot.py
@@ -150,6 +150,7 @@ class CR_HalftoneGrid:
             
         img_buf = io.BytesIO()
         plt.savefig(img_buf, format='png')
+        plt.close()
         img = Image.open(img_buf)
 
         image_out = pil2tensor(img.convert("RGB"))
@@ -253,6 +254,7 @@ class CR_ColorBars:
 
         img_buf = io.BytesIO()
         plt.savefig(img_buf, format='png')
+        plt.close()
         img = Image.open(img_buf)
         
         image_out = pil2tensor(img.convert("RGB"))
@@ -323,6 +325,7 @@ class CR_StyleBars:
 
         img_buf = io.BytesIO()
         plt.savefig(img_buf, format='png')
+        plt.close()
         img = Image.open(img_buf)
         
         image_out = pil2tensor(img.convert("RGB"))        
@@ -420,6 +423,7 @@ class CR_ColorGradient:
 
         img_buf = io.BytesIO()
         plt.savefig(img_buf, format='png')
+        plt.close()
         img = Image.open(img_buf)
         
         image_out = pil2tensor(img.convert("RGB"))         
@@ -494,6 +498,7 @@ class CR_RadialGradient:
 
         img_buf = io.BytesIO()
         plt.savefig(img_buf, format='png')
+        plt.close()
         img = Image.open(img_buf)
 
         image_out = pil2tensor(img.convert("RGB"))
@@ -574,6 +579,7 @@ class CR_CheckerPattern:
 
         img_buf = io.BytesIO()
         plt.savefig(img_buf, format='png')
+        plt.close()
         img = Image.open(img_buf)
 
         image_out = pil2tensor(img.convert("RGB"))         
@@ -661,6 +667,7 @@ class CR_Polygons:
                  
         img_buf = io.BytesIO()
         plt.savefig(img_buf, format='png')
+        plt.close()
         img = Image.open(img_buf)
 
         image_out = pil2tensor(img.convert("RGB"))         
@@ -743,6 +750,7 @@ class CR_StarburstLines:
    
         img_buf = io.BytesIO()
         plt.savefig(img_buf, format='png')
+        plt.close()
         img = Image.open(img_buf)
 
         image_out = pil2tensor(img.convert("RGB"))         
@@ -838,6 +846,7 @@ class CR_StarburstColors:
 
         img_buf = io.BytesIO()
         plt.savefig(img_buf, format='png')
+        plt.close()
         img = Image.open(img_buf)
 
         image_out = pil2tensor(img.convert("RGB"))         


### PR DESCRIPTION
Matplotlib will complain if enough opened plots go unclosed, since apparently it keeps a reference to them somewhere forever unless the `close()` function is called.

```
/home/sd/git/ComfyUI/custom_nodes/ComfyUI_Comfyroll_CustomNodes/nodes/nodes_graphics_matplot.py:135: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`). Consider using `matplotlib.pyplot.close()`.
```