### PR TITLE
replace platform dependent path separators

### DIFF
--- a/nodes/nodes_animation_schedules.py
+++ b/nodes/nodes_animation_schedules.py
@@ -215,7 +215,7 @@ class CR_OutputScheduleToFile:
     CATEGORY = icons.get("Comfyroll/Animation/Schedule") 
     
     def csvoutput(self, output_file_path, file_name, schedule, file_extension):
-        filepath = output_file_path + "\\" + file_name + "." + file_extension
+        filepath = os.path.join(output_file_path, file_name + "." + file_extension)
         
         index = 2
 
@@ -225,7 +225,7 @@ class CR_OutputScheduleToFile:
 
         while os.path.exists(filepath):
             if os.path.exists(filepath):
-                filepath = output_file_path + "\\" + file_name + str(index) + "." + file_extension
+                filepath = os.path.join(output_file_path, file_name + str(index) + "." + file_extension)
 
                 index = index + 1
             else:
@@ -267,7 +267,7 @@ class CR_LoadScheduleFromFile:
     
         show_help = "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/Schedule-Nodes#cr-load-schedule-from-file"
         
-        filepath = input_file_path + "\\" + file_name + "." + file_extension
+        filepath = os.path.join(input_file_path, file_name + "." + file_extension)
         print(f"CR Load Schedule From File: Loading {filepath}")
         
         lists = []

--- a/nodes/nodes_list.py
+++ b/nodes/nodes_list.py
@@ -554,7 +554,7 @@ class CR_LoadTextList:
            
         show_help = "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/List-Nodes#cr-load-value-list"      
 
-        filepath = input_file_path + "\\" + file_name + "." + file_extension
+        filepath = os.path.join(input_file_path, file_name + "." + file_extension)
         print(f"CR Load Values: Loading {filepath}")
 
         list = []

--- a/nodes/nodes_utils_text.py
+++ b/nodes/nodes_utils_text.py
@@ -162,7 +162,7 @@ class CR_SaveTextToFile:
     
         show_help =  "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/wiki/List-Nodes#cr-save-text-to-file" 
     
-        filepath = output_file_path + "\\" + file_name + "." + file_extension
+        filepath = os.path.join(output_file_path, file_name + "." + file_extension)
  
         index = 1
 
@@ -172,7 +172,7 @@ class CR_SaveTextToFile:
 
         while os.path.exists(filepath):
             if os.path.exists(filepath):
-                filepath = output_file_path + "\\" + file_name + "_" + str(index) + "." + file_extension
+                filepath = os.path.join(output_file_path, file_name + "_" + str(index) + "." + file_extension)
                 index = index + 1
             else:
                 break            


### PR DESCRIPTION
When trying to save a text, the path was incorrect. This pull should fix this plus some other places with a similar issue. The cause is: "\\" is windows/dos specific, Linux, mac or android use "/" instead. Thanks!
