### PR TITLE
fixed cr load lora loaded_lora deletion

### DIFF
--- a/nodes/nodes_lora.py
+++ b/nodes/nodes_lora.py
@@ -54,7 +54,7 @@ class CR_LoraLoader:
             if self.loaded_lora[0] == lora_path:
                 lora = self.loaded_lora[1]
             else:
-                del self.loaded_lora
+                self.loaded_lora = None
 
         if lora is None:
             lora = comfy.utils.load_torch_file(lora_path, safe_load=True)


### PR DESCRIPTION
Deleting `self.loaded_lora` effectively remove the member from the class. 
Not an issue in most cases as the following lines will reattribute it with the new loaded LoRA. 
But if `self.load_lora` wasn't `None`, different from `lora_path` and `lora_path` is an invalid path, then the deletion happen but no new value is attributed to `self.load_lora` as` comfy.utils.load_torch_file()` fails and crash. 
 Then at the next execution, since `self.loaded_lora` does not exists, the check for `self.load_lora is not None` crash. 
What it means in practice is that loading a valid lora, then trying to load an incorrect one will lock the node in a invalid state until the node is reinitialized (deleted/recreated) or if the UI is restarted.
The solution is to replace the deletion with an attribution to None.