### PR TITLE
Add RedBubble and Ko-Fi to the Aspect Ratio - Banners node

### DIFF
--- a/nodes/nodes_aspect_ratio.py
+++ b/nodes/nodes_aspect_ratio.py
@@ -281,7 +281,7 @@ class CR_AspectRatioBanners:
                          "Billboard - 970x250", 
                          "Portrait - 300x1050", 
                          "Banner - 468x60", 
-                         "Leaderboard - 72'8x90",
+                         "Leaderboard - 728x90",
                          "Ko-Fi - 1200x400",
                          "Redbubble - 2400x600"]
                                  

--- a/nodes/nodes_aspect_ratio.py
+++ b/nodes/nodes_aspect_ratio.py
@@ -281,7 +281,8 @@ class CR_AspectRatioBanners:
                          "Billboard - 970x250", 
                          "Portrait - 300x1050", 
                          "Banner - 468x60", 
-                         "Leaderboard - 728x90"]
+                         "Leaderboard - 72'8x90",
+                         "Ko-Fi - 1200x400"]
                                  
         return {
             "required": {
@@ -329,7 +330,9 @@ class CR_AspectRatioBanners:
         elif aspect_ratio == "Banner - 468x60":
             width, height = 168, 60
         elif aspect_ratio == "Leaderboard - 728x90":
-            width, height = 728, 90              
+            width, height = 728, 90
+        elif aspect_ratio == "Ko-Fi - 1200x400":
+            width, height = 1200, 400    
         
         if swap_dimensions == "On":
             width, height = height, width

--- a/nodes/nodes_aspect_ratio.py
+++ b/nodes/nodes_aspect_ratio.py
@@ -282,7 +282,8 @@ class CR_AspectRatioBanners:
                          "Portrait - 300x1050", 
                          "Banner - 468x60", 
                          "Leaderboard - 72'8x90",
-                         "Ko-Fi - 1200x400"]
+                         "Ko-Fi - 1200x400",
+                         "Redbubble - 2400x600"]
                                  
         return {
             "required": {
@@ -333,7 +334,9 @@ class CR_AspectRatioBanners:
             width, height = 728, 90
         elif aspect_ratio == "Ko-Fi - 1200x400":
             width, height = 1200, 400    
-        
+        elif aspect_ratio == "Redbubble - 2400x600":
+            width, height = 2400, 600 
+            
         if swap_dimensions == "On":
             width, height = height, width
         


### PR DESCRIPTION
Simple push to add Ko-Fi and Redbubble aspect ratios to the banners aspect ratio node.