### PR TITLE
Set matplotlib backend to Agg to resolve NSWindow thread issues on ma…

### DIFF
--- a/nodes/nodes_graphics_matplot.py
+++ b/nodes/nodes_graphics_matplot.py
@@ -12,6 +12,10 @@ import folder_paths
 from PIL import Image
 from ..categories import icons
 
+# Set the matplotlib backend to Agg (non-GUI) to avoid NSWindow thread issues on macOS
+import matplotlib
+matplotlib.use('Agg')
+
 try:
     import matplotlib.pyplot as plt
 except ImportError:

--- a/nodes/nodes_utils_random.py
+++ b/nodes/nodes_utils_random.py
@@ -8,6 +8,10 @@ import string
 from .functions_graphics import random_hex_color, random_rgb
 from ..categories import icons
 
+# Set the matplotlib backend to Agg (non-GUI) to avoid NSWindow thread issues on macOS
+import matplotlib
+matplotlib.use('Agg')
+
 try:
     import matplotlib.pyplot as plt
     import matplotlib.colors as mcolors


### PR DESCRIPTION

# Fix matplotlib backend issues on macOS with Apple Silicon

## Issue Description
When running ComfyUI with the Comfyroll CustomNodes plugin on macOS with Apple Silicon (M3 Max specifically), the application crashes with the following error:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'NSWindow should only be instantiated on the main thread!'
```

This crash happens because matplotlib attempts to create UI windows on a non-main thread, which isn't allowed in macOS's threading and window management model.

## Solution
This PR sets the matplotlib backend to 'Agg' (a non-GUI backend) before importing pyplot in the two files that use matplotlib:
- `nodes/nodes_graphics_matplot.py`
- `nodes/nodes_utils_random.py`

The changes are minimal and non-invasive, adding just the following lines to each file before import:

```python
# Set the matplotlib backend to Agg (non-GUI) to avoid NSWindow thread issues on macOS
import matplotlib
matplotlib.use('Agg')
```

## Technical Details
The matplotlib 'Agg' backend is a non-interactive backend that renders figures as PNG images without creating any GUI windows. This avoids the thread-related issues on macOS while preserving all the image generation functionality needed by the Comfyroll nodes.

This is a common solution for applications that use matplotlib in background/worker threads or in server environments where no display is available.

## Testing
- Tested on macOS Sonoma (14.7) with M3 Max chip
- After applying these changes, ComfyUI successfully launches and runs without the NSWindow threading exception
- All Comfyroll nodes that use matplotlib continue to function properly

## Platform Impact
This fix should have no impact on functionality on other platforms (Windows, Linux), as it only affects how matplotlib renders images behind the scenes. The 'Agg' backend is universally available across all platforms where matplotlib is installed.

The change is conservative and focused only on addressing the macOS thread issue while maintaining full compatibility with existing workflows.
