### PR TITLE
fixed the upscaler by updating to use the configured torch device

### DIFF
--- a/nodes/functions_upscale.py
+++ b/nodes/functions_upscale.py
@@ -54,7 +54,7 @@ def upscale_with_model(upscale_model, image):
             if tile < 128:
                 raise e
 
-    upscale_model.cpu()
+    upscale_model.to(device)
     s = torch.clamp(s.movedim(-3,-1), min=0, max=1.0)
     return s        
 


### PR DESCRIPTION
The old .cpu() syntax is no longer supported in torch. This is a simple update to the new syntax using whatever torch device has been configured. This was breaking the CR Upscaler node, and anything else that depends on the upscaler function library.